### PR TITLE
Add method to fetch BearerToken from Header / Cookies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/common v0.15.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.7.0
 	github.com/valyala/fasthttp v1.20.0
 	go.uber.org/zap v1.16.0
 	google.golang.org/grpc v1.35.0

--- a/receive.go
+++ b/receive.go
@@ -57,6 +57,12 @@ func (r *request) receiveFile(address *object.Address) {
 		filename string
 	)
 
+	if err = checkAndPropagateBearerToken(r.RequestCtx); err != nil {
+		r.log.Error("could not fetch bearer token", zap.Error(err))
+		r.Error("could not fetch bearer token", fasthttp.StatusBadRequest)
+		return
+	}
+
 	writer := newDetector(r.Response.BodyWriter())
 	obj, err := r.obj.Get(r, address, sdk.WithGetWriter(writer))
 	if err != nil {

--- a/upload.go
+++ b/upload.go
@@ -44,6 +44,12 @@ func (a *app) upload(c *fasthttp.RequestCtx) {
 		log = a.log.With(zap.String("cid", sCID))
 	)
 
+	if err = checkAndPropagateBearerToken(c); err != nil {
+		log.Error("could not fetch bearer token", zap.Error(err))
+		c.Error("could not fetch bearer token", fasthttp.StatusBadRequest)
+		return
+	}
+
 	if err = cid.Parse(sCID); err != nil {
 		log.Error("wrong container id", zap.Error(err))
 		c.Error("wrong container id", fasthttp.StatusBadRequest)


### PR DESCRIPTION
- `BearerToken` allow to parse header/cookies to fetch bearer token
- `fromHeader` allow to parse header to fetch bearer token base64 data
- `fromCookie` allow to parse header to fetch bearer token base64 data

closes #2
closes #11

Signed-off-by: Evgeniy Kulikov <kim@nspcc.ru>

!!! Should me merged after #12 !!!
See more - https://github.com/nspcc-dev/neofs-http-gate/pull/13#issuecomment-766867573