### PR TITLE
*: use client.Object where appropriate

### DIFF
--- a/downloader/download.go
+++ b/downloader/download.go
@@ -72,7 +72,7 @@ func isValidValue(s string) bool {
 	return true
 }
 
-func (r *request) receiveFile(clnt client.Client,
+func (r *request) receiveFile(clnt client.Object,
 	sessionToken *session.Token,
 	objectAddress *object.Address) {
 	var (
@@ -194,7 +194,7 @@ func (d *Downloader) DownloadByAddress(c *fasthttp.RequestCtx) {
 		oid, _  = c.UserValue("oid").(string)
 		val     = strings.Join([]string{cid, oid}, "/")
 		log     = d.log.With(zap.String("cid", cid), zap.String("oid", oid))
-		conn    client.Client
+		conn    client.Object
 		tkn     *session.Token
 	)
 	if err = address.Parse(val); err != nil {
@@ -221,7 +221,7 @@ func (d *Downloader) DownloadByAttribute(c *fasthttp.RequestCtx) {
 		val, _  = c.UserValue("attr_val").(string)
 		log     = d.log.With(zap.String("cid", scid), zap.String("attr_key", key), zap.String("attr_val", val))
 		ids     []*object.ID
-		conn    client.Client
+		conn    client.Object
 		tkn     *session.Token
 	)
 	cid := cid.New()

--- a/uploader/upload.go
+++ b/uploader/upload.go
@@ -43,7 +43,7 @@ func (u *Uploader) Upload(c *fasthttp.RequestCtx) {
 		err        error
 		file       MultipartFile
 		obj        *object.ID
-		conn       client.Client
+		conn       client.Object
 		tkn        *session.Token
 		addr       = object.NewAddress()
 		cid        = cid.New()


### PR DESCRIPTION
It's enough to do the job, we don't really need full client.Client interface
here.

Signed-off-by: Roman Khimov <roman@nspcc.ru>