### PR TITLE
downloader: fix Last-Modified header

### DIFF
--- a/downloader/download.go
+++ b/downloader/download.go
@@ -186,7 +186,7 @@ func (r *request) receiveFile(clnt client.Object, objectAddress *object.Address)
 				continue
 			}
 			r.Response.Header.Set("Last-Modified",
-				time.Unix(value, 0).Format(time.RFC1123))
+				time.Unix(value, 0).UTC().Format(http.TimeFormat))
 		case object.AttributeContentType:
 			contentType = val
 		}


### PR DESCRIPTION
It should never ever be sent in local time, instead of
  Last-Modified: Tue, 29 Jun 2021 12:02:57 MSK
one should receive
  Last-Modified: Tue, 29 Jun 2021 09:02:57 GMT

Signed-off-by: Roman Khimov <roman@nspcc.ru>