### PR TITLE
test: Set up pool with SessionExpiration value

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"sort"
@@ -35,7 +36,7 @@ type putResponse struct {
 func TestIntegration(t *testing.T) {
 	rootCtx := context.Background()
 	aioImage := "nspccdev/neofs-aio-testcontainer:"
-	versions := []string{"0.24.0", "0.25.1", "latest"}
+	versions := []string{"0.24.0", "0.25.1", "0.26.1", "latest"}
 	key, err := keys.NewPrivateKeyFromHex("1dd37fba80fec4e6a6f13fd708d8dcb3b29def768017052f6c930fa1c5d90bbb")
 	require.NoError(t, err)
 
@@ -269,9 +270,10 @@ func getPool(ctx context.Context, t *testing.T, key *keys.PrivateKey) pool.Pool 
 	pb.AddNode("localhost:8080", 1)
 
 	opts := &pool.BuilderOptions{
-		Key:                   &key.PrivateKey,
-		NodeConnectionTimeout: 5 * time.Second,
-		NodeRequestTimeout:    5 * time.Second,
+		Key:                    &key.PrivateKey,
+		NodeConnectionTimeout:  5 * time.Second,
+		NodeRequestTimeout:     5 * time.Second,
+		SessionExpirationEpoch: math.MaxUint64,
 	}
 	clientPool, err := pb.Build(ctx, opts)
 	require.NoError(t, err)


### PR DESCRIPTION
neofs-node v0.26.1 release tracks session token expiration more closely, so it has to be specified correctly.

Merge after https://github.com/nspcc-dev/neofs-aio/pull/8