### PR TITLE
[#109] GW version

### DIFF
--- a/app.go
+++ b/app.go
@@ -179,7 +179,7 @@ func getKeyFromWallet(w *wallet.Wallet, addrStr string, password *string) (*ecds
 }
 
 func (a *app) Wait() {
-	a.log.Info("starting application")
+	a.log.Info("starting application", zap.String("version", a.cfg.GetString(cfgApplicationVersion)))
 	<-a.webDone // wait for web-server to be stopped
 }
 


### PR DESCRIPTION
Closes #109 

Also fixed print of version in --help and --version. Earlier default version `dev` has been always printed in responses to these commands. Now we print the following way: 

- if version is set in env : `-v` and `-h` print the value from env
- if config is set and env is not: `-v` prints config version, `-h` -- default version (because we print default `Default environments` in help.
- If neither env nor config are set: dev in `-v` and `-h`. 