### PR TITLE
[#11] Fix headers format

### DIFF
--- a/downloader/download.go
+++ b/downloader/download.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-http-gw/response"
 	"github.com/nspcc-dev/neofs-http-gw/tokens"
+	"github.com/nspcc-dev/neofs-http-gw/utils"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
@@ -152,7 +153,7 @@ func (r request) receiveFile(clnt pool.Object, objectAddress *object.Address) {
 		if !isValidToken(key) || !isValidValue(val) {
 			continue
 		}
-		r.Response.Header.Set("X-Attribute-"+key, val)
+		r.Response.Header.Set(utils.UserAttributeHeaderPrefix+key, val)
 		switch key {
 		case object.AttributeFileName:
 			filename = val

--- a/downloader/download.go
+++ b/downloader/download.go
@@ -175,9 +175,9 @@ func (r request) receiveFile(clnt pool.Object, objectAddress *object.Address) {
 			contentType = val
 		}
 	}
-	r.Response.Header.Set("x-object-id", obj.ID().String())
-	r.Response.Header.Set("x-owner-id", obj.OwnerID().String())
-	r.Response.Header.Set("x-container-id", obj.ContainerID().String())
+	r.Response.Header.Set("X-Object-Id", obj.ID().String())
+	r.Response.Header.Set("X-Owner-Id", obj.OwnerID().String())
+	r.Response.Header.Set("X-Container-Id", obj.ContainerID().String())
 
 	if len(contentType) == 0 {
 		if readDetector.err != nil {

--- a/downloader/download_test.go
+++ b/downloader/download_test.go
@@ -1,0 +1,23 @@
+package downloader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSystemBackwardTranslator(t *testing.T) {
+	input := []string{
+		"__NEOFS__EXPIRATION_EPOCH",
+		"__NEOFS__RANDOM_ATTR",
+	}
+	expected := []string{
+		"Neofs-Expiration-Epoch",
+		"Neofs-Random-Attr",
+	}
+
+	for i, str := range input {
+		res := systemBackwardTranslator(str)
+		require.Equal(t, expected[i], res)
+	}
+}

--- a/downloader/head.go
+++ b/downloader/head.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-http-gw/response"
 	"github.com/nspcc-dev/neofs-http-gw/tokens"
+	"github.com/nspcc-dev/neofs-http-gw/utils"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	"github.com/nspcc-dev/neofs-sdk-go/pool"
@@ -40,7 +41,7 @@ func (r request) headObject(clnt pool.Object, objectAddress *object.Address) {
 		if !isValidToken(key) || !isValidValue(val) {
 			continue
 		}
-		r.Response.Header.Set("X-Attribute-"+key, val)
+		r.Response.Header.Set(utils.UserAttributeHeaderPrefix+key, val)
 		switch key {
 		case object.AttributeTimestamp:
 			value, err := strconv.ParseInt(val, 10, 64)

--- a/uploader/filter_test.go
+++ b/uploader/filter_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
-
+	"github.com/nspcc-dev/neofs-http-gw/utils"
 	"github.com/nspcc-dev/neofs-sdk-go/logger"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -71,8 +71,8 @@ func TestPrepareExpirationHeader(t *testing.T) {
 		{
 			name: "valid epoch, valid duration",
 			headers: map[string]string{
-				object.SysAttributeExpEpoch: epoch,
-				expirationDurationAttr:      duration,
+				object.SysAttributeExpEpoch:  epoch,
+				utils.ExpirationDurationAttr: duration,
 			},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: epoch},
@@ -81,7 +81,7 @@ func TestPrepareExpirationHeader(t *testing.T) {
 			name: "valid epoch, valid rfc3339",
 			headers: map[string]string{
 				object.SysAttributeExpEpoch: epoch,
-				expirationRFC3339Attr:       tomorrow.Format(time.RFC3339),
+				utils.ExpirationRFC3339Attr: tomorrow.Format(time.RFC3339),
 			},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: epoch},
@@ -89,8 +89,8 @@ func TestPrepareExpirationHeader(t *testing.T) {
 		{
 			name: "valid epoch, valid timestamp sec",
 			headers: map[string]string{
-				object.SysAttributeExpEpoch: epoch,
-				expirationTimestampAttr:     timestampSec,
+				object.SysAttributeExpEpoch:   epoch,
+				utils.ExpirationTimestampAttr: timestampSec,
 			},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: epoch},
@@ -98,8 +98,8 @@ func TestPrepareExpirationHeader(t *testing.T) {
 		{
 			name: "valid epoch, valid timestamp milli",
 			headers: map[string]string{
-				object.SysAttributeExpEpoch: epoch,
-				expirationTimestampAttr:     timestampMilli,
+				object.SysAttributeExpEpoch:   epoch,
+				utils.ExpirationTimestampAttr: timestampMilli,
 			},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: epoch},
@@ -107,58 +107,58 @@ func TestPrepareExpirationHeader(t *testing.T) {
 		{
 			name: "valid epoch, valid timestamp nano",
 			headers: map[string]string{
-				object.SysAttributeExpEpoch: epoch,
-				expirationTimestampAttr:     timestampNano,
+				object.SysAttributeExpEpoch:   epoch,
+				utils.ExpirationTimestampAttr: timestampNano,
 			},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: epoch},
 		},
 		{
 			name:      "valid timestamp sec",
-			headers:   map[string]string{expirationTimestampAttr: timestampSec},
+			headers:   map[string]string{utils.ExpirationTimestampAttr: timestampSec},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: defaultExpEpoch},
 		},
 		{
 			name:      "valid duration",
-			headers:   map[string]string{expirationDurationAttr: duration},
+			headers:   map[string]string{utils.ExpirationDurationAttr: duration},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: defaultExpEpoch},
 		},
 		{
 			name:      "valid rfc3339",
-			headers:   map[string]string{expirationRFC3339Attr: tomorrow.Format(time.RFC3339)},
+			headers:   map[string]string{utils.ExpirationRFC3339Attr: tomorrow.Format(time.RFC3339)},
 			durations: defaultDurations,
 			expected:  map[string]string{object.SysAttributeExpEpoch: defaultExpEpoch},
 		},
 		{
 			name:    "invalid timestamp sec",
-			headers: map[string]string{expirationTimestampAttr: "abc"},
+			headers: map[string]string{utils.ExpirationTimestampAttr: "abc"},
 			err:     true,
 		},
 		{
 			name:    "invalid timestamp sec zero",
-			headers: map[string]string{expirationTimestampAttr: "0"},
+			headers: map[string]string{utils.ExpirationTimestampAttr: "0"},
 			err:     true,
 		},
 		{
 			name:    "invalid duration",
-			headers: map[string]string{expirationDurationAttr: "1d"},
+			headers: map[string]string{utils.ExpirationDurationAttr: "1d"},
 			err:     true,
 		},
 		{
 			name:    "invalid duration negative",
-			headers: map[string]string{expirationDurationAttr: "-5h"},
+			headers: map[string]string{utils.ExpirationDurationAttr: "-5h"},
 			err:     true,
 		},
 		{
 			name:    "invalid rfc3339",
-			headers: map[string]string{expirationRFC3339Attr: "abc"},
+			headers: map[string]string{utils.ExpirationRFC3339Attr: "abc"},
 			err:     true,
 		},
 		{
 			name:    "invalid rfc3339 zero",
-			headers: map[string]string{expirationRFC3339Attr: time.RFC3339},
+			headers: map[string]string{utils.ExpirationRFC3339Attr: time.RFC3339},
 			err:     true,
 		},
 	} {

--- a/uploader/upload.go
+++ b/uploader/upload.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-http-gw/response"
 	"github.com/nspcc-dev/neofs-http-gw/tokens"
+	"github.com/nspcc-dev/neofs-http-gw/utils"
 	"github.com/nspcc-dev/neofs-sdk-go/client"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
@@ -220,8 +221,8 @@ func getEpochDurations(ctx context.Context, p pool.Pool) (*epochDurations, error
 }
 
 func needParseExpiration(headers map[string]string) bool {
-	_, ok1 := headers[expirationDurationAttr]
-	_, ok2 := headers[expirationRFC3339Attr]
-	_, ok3 := headers[expirationTimestampAttr]
+	_, ok1 := headers[utils.ExpirationDurationAttr]
+	_, ok2 := headers[utils.ExpirationRFC3339Attr]
+	_, ok3 := headers[utils.ExpirationTimestampAttr]
 	return ok1 || ok2 || ok3
 }

--- a/utils/attributes.go
+++ b/utils/attributes.go
@@ -1,0 +1,10 @@
+package utils
+
+const (
+	UserAttributeHeaderPrefix = "X-Attribute-"
+	SystemAttributePrefix     = "__NEOFS__"
+
+	ExpirationDurationAttr  = SystemAttributePrefix + "EXPIRATION_DURATION"
+	ExpirationTimestampAttr = SystemAttributePrefix + "EXPIRATION_TIMESTAMP"
+	ExpirationRFC3339Attr   = SystemAttributePrefix + "EXPIRATION_RFC3339"
+)


### PR DESCRIPTION
Closes #111

Also moved attribute/headers constants to a separate file `util/attributes.go`. I'm not sure that the name is correct/good enough,  but I have no better idea about the name.