### PR TITLE
Remove race condition check in integration test

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -1,3 +1,6 @@
+//go:build !race
+// +build !race
+
 package main
 
 import (


### PR DESCRIPTION
Race condition checks are suitable for unit tests
but mostly useless in case of full-size integration
test with neofs-all-in-one test container.

Should fix fail of data coverage action.