### PR TITLE
Replace `go get` with `go install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NeoFS HTTP Gateway bridges NeoFS internal protocol and HTTP standard.
 
 ## Installation
 
-```go get -u github.com/nspcc-dev/neofs-http-gw```
+```go install github.com/nspcc-dev/neofs-http-gw```
 
 Or you can call `make` to build it from the cloned repository (the binary will
 end up in `bin/neofs-http-gw`).


### PR DESCRIPTION
Since Go 1.16, go install can install a command at a version specified on the command line while. Starting in Go 1.17, installing executables with go get is deprecated.