### PR TITLE
Use application context in NeoFS API requests 

### DIFF
--- a/app.go
+++ b/app.go
@@ -208,8 +208,8 @@ func (a *app) Serve(ctx context.Context) {
 		close(a.webDone)
 	}()
 	edts := a.cfg.GetBool(cfgUploaderHeaderEnableDefaultTimestamp)
-	uploader := uploader.New(a.log, a.pool, edts)
-	downloader := downloader.New(a.log, downloader.Settings{ZipCompression: a.cfg.GetBool(cfgZipCompression)}, a.pool)
+	uploader := uploader.New(ctx, a.log, a.pool, edts)
+	downloader := downloader.New(ctx, a.log, downloader.Settings{ZipCompression: a.cfg.GetBool(cfgZipCompression)}, a.pool)
 	// Configure router.
 	r := router.New()
 	r.RedirectTrailingSlash = true

--- a/downloader/head.go
+++ b/downloader/head.go
@@ -39,7 +39,7 @@ func (r request) headObject(clnt *pool.Pool, objectAddress *address.Address) {
 	prm.SetAddress(*objectAddress)
 	prm.UseBearer(btoken)
 
-	obj, err := clnt.HeadObject(r.RequestCtx, prm)
+	obj, err := clnt.HeadObject(r.appCtx, prm)
 	if err != nil {
 		r.handleNeoFSErr(err, start)
 		return
@@ -79,7 +79,7 @@ func (r request) headObject(clnt *pool.Pool, objectAddress *address.Address) {
 			prmRange.SetLength(sz)
 			prmRange.UseBearer(btoken)
 
-			return clnt.ObjectRange(r.RequestCtx, prmRange)
+			return clnt.ObjectRange(r.appCtx, prmRange)
 		})
 		if err != nil && err != io.EOF {
 			r.handleNeoFSErr(err, start)


### PR DESCRIPTION
It is meaningless to use RequestCtx as a context.Context
for NeoFS operation, because context won't be closed
until application shutdown. Moreover, it also triggers
data race detection, because server's done channel, which
is accessible for reading from RequestCtx, is set to `nil`.

Using application context doesn't change gateway behavior,
but it suppresses data race trigger at shutdown. It also
allows possibility to set configurable timeouts for NeoFS
networking if we will ever need them.