### PR TITLE
Update default values for HTTP_GW_READ/WRITE_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ You can tune HTTP read and write buffer sizes as well as timeouts with
 `HTTP_GW_WEB_WRITE_BUFFER_SIZE` and `HTTP_GW_WEB_WRITE_TIMEOUT` environment
 variables.
 
+**Note:** to allow upload and download of big data streams, disable read
+and write timeouts correspondingly. To do that, set `HTTP_GW_WEB_READ_TIMEOUT=0`
+and `HTTP_GW_WEB_WRITE_TIMEOUT=0`. Otherwise, HTTP Gateway will terminate
+request with data stream after timeout.
+
 `HTTP_GW_WEB_STREAM_REQUEST_BODY` environment variable can be used to disable
 request body streaming (effectively it'll make gateway accept file completely
 first and only then try sending it to NeoFS).

--- a/config/config.env
+++ b/config/config.env
@@ -53,11 +53,11 @@ HTTP_GW_WRITE_BUFFER_SIZE=4096
 # the full request including body. The connection's read
 # deadline is reset when the connection opens, or for
 # keep-alive connections after the first byte has been read.
-HTTP_GW_READ_TIMEOUT=15s
+HTTP_GW_READ_TIMEOUT=10m
 # WriteTimeout is the maximum duration before timing out
 # writes of the response. It is reset after the request handler
 # has returned.
-HTTP_GW_WRITE_TIMEOUT=1m
+HTTP_GW_WRITE_TIMEOUT=5m
 # StreamRequestBody enables request body streaming,
 # and calls the handler sooner when given body is
 # larger then the current limit.

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -50,12 +50,12 @@ web:
   # the full request including body. The connection's read
   # deadline is reset when the connection opens, or for
   # keep-alive connections after the first byte has been read.
-  read_timeout: 15s
+  read_timeout: 10m
 
   # WriteTimeout is the maximum duration before timing out
   # writes of the response. It is reset after the request handler
   # has returned.
-  write_timeout: 1m
+  write_timeout: 5m
 
   # StreamRequestBody enables request body streaming,
   # and calls the handler sooner when given body is

--- a/settings.go
+++ b/settings.go
@@ -107,8 +107,8 @@ func settings() *viper.Viper {
 	// web-server:
 	v.SetDefault(cfgWebReadBufferSize, 4096)
 	v.SetDefault(cfgWebWriteBufferSize, 4096)
-	v.SetDefault(cfgWebReadTimeout, time.Second*15)
-	v.SetDefault(cfgWebWriteTimeout, time.Minute)
+	v.SetDefault(cfgWebReadTimeout, time.Minute*10)
+	v.SetDefault(cfgWebWriteTimeout, time.Minute*5)
 	v.SetDefault(cfgWebStreamRequestBody, true)
 	v.SetDefault(cfgWebMaxRequestBodySize, fasthttp.DefaultMaxRequestBodySize)
 


### PR DESCRIPTION
10 minute upload and 5 minute download timeouts are long enough
to handle average size objects in the real networks. For big
data streams these timeouts should be disabled.

Closes #146 