### PR TITLE
[#163] Fix zip streaming

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -276,7 +276,7 @@ func makeZipRequest(t *testing.T, url string, names, contents []string) {
 
 	data, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
-	checkZip(t, data, resp.ContentLength, names, contents)
+	checkZip(t, data, int64(len(data)), names, contents)
 }
 
 func checkZip(t *testing.T, data []byte, length int64, names, contents []string) {


### PR DESCRIPTION
Declined to use `(*zip.Writer).CreateRaw()` as it does not result in a noticeable performance increase, but introduces unnecessary complexity.

Increased buffer to download zip archive up to 3MB (the same as for upload files).
Started using `(*fasthttp.RequestCtx).SetBodyStreamWriter()` to get rid of of accumulation of response body in application memory.

close #163 
Signed-off-by: Denis Kirillov <denis@nspcc.ru>