### PR TITLE
Fix expiration epoch calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document outlines major changes between releases.
 
+## Unreleased
+
+### Fixed
+- Fix expiration epoch calculation (#198)
+
 ## [0.23.0] - 2022-08-02
 
 ### Added
@@ -205,3 +210,4 @@ releases.
 [0.21.0]: https://github.com/nspcc-dev/neofs-http-gw/compare/v0.20.0...v0.21.0
 [0.22.0]: https://github.com/nspcc-dev/neofs-http-gw/compare/v0.21.0...v0.22.0
 [0.23.0]: https://github.com/nspcc-dev/neofs-http-gw/compare/v0.22.0...v0.23.0
+[Unreleased]: https://github.com/nspcc-dev/neofs-rest-gw/compare/v0.23.0...master


### PR DESCRIPTION
Previous implementation does not provide 'at least' lifetime guarantee.

Implementation is taken from [neofs-s3-gw](https://github.com/nspcc-dev/neofs-s3-gw/blob/272c4857062eeba8728333c16f3c88e51e7d8d3a/internal/neofs/neofs.go#L55)

Related to https://github.com/nspcc-dev/neofs-node/issues/1670

According to specification, expiration epoch is last epoch when object is available. We set expiration epoch such way that it crosses lifetime limit. Next epoch after will remove an object. 

```
current epoch: 23 (1h has passed)
epoch duration: 1.5h
lifetime: 4h
delta => 4h / 1.5h = 2.6 ~ 3.0
exp = 23 + 3 = 26

| wall time | epoch | 
|   0.0h    |  23   | <- object upload here after 1h of 23rd epoch with expectation of 4h lifetime
|   0.5h    |  24   | 
|   2.0h    |  25   | <- previous implementation sets exp=25, so on 26 (3.5h after object upload) object is removed
|   3.5h    |  26   | <- current  implementation sets exp=26, so on 27 (5.0h after object upload) object is removed
|   5.0h    |  27   |
```