### PR TITLE
[#213] Makefile: Add help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ dep:
 	@CGO_ENABLED=0 \
 	go mod tidy -v && echo OK
 
+# Run `make %` in Golang container, for more information run `make help.docker/%`
 docker/%:
 	$(if $(filter $*,all $(BINS)), \
 		@echo "=> Running 'make $*' in clean Docker environment" && \
@@ -109,3 +110,5 @@ version:
 clean:
 	rm -rf vendor
 	rm -rf $(BINDIR)
+
+include help.mk

--- a/help.mk
+++ b/help.mk
@@ -1,0 +1,22 @@
+.PHONY: help
+
+# Show this help prompt
+help:
+	@echo '  Usage:'
+	@echo ''
+	@echo '    make <target>'
+	@echo ''
+	@echo '  Targets:'
+	@echo ''
+	@awk '/^#/{ comment = substr($$0,3) } comment && /^[a-zA-Z][a-zA-Z0-9.%_/-]+ ?:/{ print "   ", $$1, comment }' $(MAKEFILE_LIST) | column -t -s ':' | grep -v 'IGNORE' | sort | uniq
+
+# Show help for docker/% IGNORE
+help.docker/%:
+	$(eval TARGETS:=$(notdir all lint) ${BINS})
+	@echo '  Usage:'
+	@echo ''
+	@echo '    make docker/% -- Run `make %` in Golang container'
+	@echo ''
+	@echo '  Supported docker targets:'
+	@echo ''
+	@$(foreach bin, $(TARGETS), echo '   ' $(bin);)


### PR DESCRIPTION
Now it prints: 
```
 $ make help
  Usage:

    make <target>

  Targets:

    all             Make all binaries
    clean           Clean up
    cover           Run tests with race detection and produce coverage output
    dep             Pull go dependencies
    dirty-image     Build dirty Docker image
    docker/lint     Run linters in Docker
    docker/%        Run `make %` in Golang container, for more information run `make help.docker/%`
    fmt             Reformat code
    help            Show this help prompt
    image           Build clean Docker image
    image-push      Push Docker image to the hub
    lint            Run linters
    test            Run tests
    version         Print version


$ make help.docker/%
  Usage:

    make docker/% -- Run `make %` in Golang container

  Supported docker targets:

    all
    lint
    bin/neofs-http-gw

```