### PR TITLE
Add version metric fix

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -92,6 +92,7 @@ func newStateMetrics() *stateMetrics {
 
 func (m stateMetrics) register() {
 	prometheus.MustRegister(m.healthCheck)
+	prometheus.MustRegister(m.gwVersion)
 }
 
 func (m stateMetrics) unregister() {


### PR DESCRIPTION
reference #248

I have no idea how I checked it before, but without this row, Prometheus stats don't have required field with version