### PR TITLE
uploader: respect Content-Type from MIME part header

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,8 @@ $ curl -F 'file=@cat.jpeg;filename=cat.jpeg' -H 'X-Attribute-FilePath: common/pr
 You get object contents in the reply body (if GET method was used), but at the same time you also get a
 set of reply headers generated using the following rules:
  * `Content-Length` is set to the length of the object
- * `Content-Type` is autodetected dynamically by gateway
+ * `Content-Type` is taken from the object's `Content-Type` attribute or
+   autodetected dynamically by the gateway if missing
  * `Content-Disposition` is `inline` for regular requests and `attachment` for
    requests with `download=true` argument, `filename` is also added if there
    is `FileName` attribute set for this object

--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ You can also add some attributes to your file using the following rules:
    `__NEOFS__EXPIRATION_EPOCH` attribute
  * `FileName` attribute is set from multipart's `filename` if not set
    explicitly via `X-Attribute-FileName` header
+ * `Content-Type` attribute is set from multipart's `Content-Type` header if
+   not set via `X-Attribute-Content-Type` header
  * `Timestamp` attribute can be set using gateway local time if using
    HTTP_GW_UPLOAD_HEADER_USE_DEFAULT_TIMESTAMP option and if request doesn't
    provide `X-Attribute-Timestamp` header of its own

--- a/integration_test.go
+++ b/integration_test.go
@@ -43,15 +43,6 @@ const (
 	testHost          = "http://" + testListenAddress
 )
 
-var (
-	tickEpoch = []string{
-		"neo-go", "contract", "invokefunction", "--wallet-config", "/config/node-config.yaml",
-		"-a", "NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP", "--force", "-r", "http://localhost:30333",
-		"707516630852f4179af43366917a36b9a78b93a5", "newEpoch", "int:10",
-		"--", "NfgHwwTi3wHAS8aFAN243C5vGbkYDpqLHP:Global",
-	}
-)
-
 func TestIntegration(t *testing.T) {
 	versions := []string{"0.37.0", "0.38.0"}
 
@@ -354,15 +345,6 @@ func createDockerContainer(ctx context.Context, t *testing.T, image string) test
 		Started:          true,
 	})
 	require.NoError(t, err)
-
-	// Have to wait this time. Required for new tick event processing.
-	// Should be removed after fix epochs in AIO start.
-	<-time.After(3 * time.Second)
-
-	_, _, err = aioC.Exec(ctx, tickEpoch)
-	require.NoError(t, err)
-
-	<-time.After(3 * time.Second)
 
 	return aioC
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -59,7 +59,8 @@ var (
 
 func TestIntegration(t *testing.T) {
 	versions := []dockerImage{
-		{image: "nspccdev/neofs-aio", version: "0.37.0"}, // 0.37.0 is the latest
+		{image: "nspccdev/neofs-aio", version: "0.37.0"},
+		{image: "nspccdev/neofs-aio", version: "0.38.0"},
 	}
 
 	key, err := keys.NewPrivateKeyFromHex("1dd37fba80fec4e6a6f13fd708d8dcb3b29def768017052f6c930fa1c5d90bbb")

--- a/integration_test.go
+++ b/integration_test.go
@@ -37,11 +37,6 @@ type putResponse struct {
 	OID string `json:"object_id"`
 }
 
-type dockerImage struct {
-	image   string
-	version string
-}
-
 const (
 	testContainerName = "friendly"
 	testListenAddress = "localhost:8082"
@@ -58,10 +53,7 @@ var (
 )
 
 func TestIntegration(t *testing.T) {
-	versions := []dockerImage{
-		{image: "nspccdev/neofs-aio", version: "0.37.0"},
-		{image: "nspccdev/neofs-aio", version: "0.38.0"},
-	}
+	versions := []string{"0.37.0", "0.38.0"}
 
 	key, err := keys.NewPrivateKeyFromHex("1dd37fba80fec4e6a6f13fd708d8dcb3b29def768017052f6c930fa1c5d90bbb")
 	require.NoError(t, err)
@@ -70,7 +62,7 @@ func TestIntegration(t *testing.T) {
 	ownerID := signer.UserID()
 
 	for _, version := range versions {
-		image := fmt.Sprintf("%s:%s", version.image, version.version)
+		image := fmt.Sprintf("nspccdev/neofs-aio:%s", version)
 
 		ctx, cancel2 := context.WithCancel(context.Background())
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -114,8 +114,9 @@ func makePutRequestAndCheck(ctx context.Context, t *testing.T, p *pool.Pool, cnr
 	content := "content of file"
 	keyAttr, valAttr := "User-Attribute", "user value"
 	attributes := map[string]string{
-		object.AttributeFileName: "newFile.txt",
-		keyAttr:                  valAttr,
+		object.AttributeFileName:    "newFile.txt",
+		object.AttributeContentType: "application/octet-stream",
+		keyAttr:                     valAttr,
 	}
 
 	var buff bytes.Buffer

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -97,6 +97,7 @@ func (m stateMetrics) register() {
 
 func (m stateMetrics) unregister() {
 	prometheus.Unregister(m.healthCheck)
+	prometheus.Unregister(m.gwVersion)
 }
 
 func (m stateMetrics) SetHealth(s int32) {

--- a/uploader/multipart.go
+++ b/uploader/multipart.go
@@ -11,6 +11,7 @@ import (
 // get file name, it's used for multipart uploads.
 type MultipartFile interface {
 	io.ReadCloser
+	ContentType() string
 	FileName() string
 }
 

--- a/uploader/multipart/multipart.go
+++ b/uploader/multipart/multipart.go
@@ -77,6 +77,10 @@ func (p *Part) FileName() string {
 	return p.dispositionParams["filename"]
 }
 
+func (p *Part) ContentType() string {
+	return p.Header.Get("Content-Type")
+}
+
 func (p *Part) parseContentDisposition() {
 	v := p.Header.Get("Content-Disposition")
 	var err error

--- a/uploader/multipart_test.go
+++ b/uploader/multipart_test.go
@@ -98,6 +98,14 @@ func customMultipart(filename string) error {
 	return err
 }
 
+type multiFile struct {
+	*multipart.Part
+}
+
+func (*multiFile) ContentType() string {
+	return "text/plain"
+}
+
 func fetchMultipartFileDefault(l *zap.Logger, r io.Reader, boundary string) (MultipartFile, error) {
 	reader := multipart.NewReader(r, boundary)
 
@@ -122,7 +130,7 @@ func fetchMultipartFileDefault(l *zap.Logger, r io.Reader, boundary string) (Mul
 			continue
 		}
 
-		return part, nil
+		return &multiFile{part}, nil
 	}
 }
 

--- a/uploader/upload.go
+++ b/uploader/upload.go
@@ -168,6 +168,13 @@ func (u *Uploader) Upload(c *fasthttp.RequestCtx) {
 		filename.SetValue(file.FileName())
 		attributes = append(attributes, *filename)
 	}
+	// sets Content-Type attribute if it wasn't set from header
+	if _, ok := filtered[object.AttributeContentType]; !ok && file.ContentType() != "" {
+		cType := object.NewAttribute()
+		cType.SetKey(object.AttributeContentType)
+		cType.SetValue(file.ContentType())
+		attributes = append(attributes, *cType)
+	}
 	// sets Timestamp attribute if it wasn't set from header and enabled by settings
 	if _, ok := filtered[object.AttributeTimestamp]; !ok && u.settings.DefaultTimestamp() {
 		timestamp := object.NewAttribute()


### PR DESCRIPTION
It makes sense in general (since HTTP Content-Type is multipart/form) and browsers usually set it. This will help to have a more secure send.fs.neo.org since explicit Content-Type is then always returned for GETs (otherwise it's autodetected).